### PR TITLE
Add markdownlint workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actionshub/markdownlint@v3
         with:
-          node-version: '18'
-      - run: npx markdownlint-cli README.md
+          args: README.md


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run markdownlint on README.md

## Testing
- `npx markdownlint-cli README.md` *(fails: 403 Forbidden due to no internet)*

------
https://chatgpt.com/codex/tasks/task_b_684d7466da8483338e63e12bf5e75b66