### PR TITLE
Add daily AI news section

### DIFF
--- a/.github/workflows/update_news.yml
+++ b/.github/workflows/update_news.yml
@@ -1,0 +1,38 @@
+name: Update News
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-news:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Update README with latest news
+        env:
+          NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
+        run: python scripts/update_news.py
+
+      - name: Commit and push changes
+        run: |
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@github.com'
+          git add README.md
+          if git diff --cached --quiet; then
+            echo 'No changes to commit'
+          else
+            git commit -m 'Update news section'
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Currently I am upskilling myself on Spark so that I can take my work to the next
 ![[Header](https://youtu.be/oCITP8OcqjE "cover")]
 
 
+## Latest AI News
+<!-- NEWS-START -->
+<!-- NEWS-END -->
 
 ## 🔧 Technologies & Tools
 ![](https://img.shields.io/badge/OS-Linux-informational?style=flat&logo=linux&logoColor=white&color=2bbc8a)

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -1,0 +1,48 @@
+import os
+import requests
+
+API_KEY = os.getenv("NEWS_API_KEY")
+if not API_KEY:
+    raise EnvironmentError("NEWS_API_KEY environment variable not set")
+
+QUERY = "artificial intelligence"
+API_URL = f"https://newsdata.io/api/1/latest?apikey={API_KEY}&q={QUERY}"
+
+response = requests.get(API_URL, timeout=10)
+response.raise_for_status()
+data = response.json()
+
+articles = data.get("results", [])[:5]
+
+lines = []
+for article in articles:
+    title = article.get("title")
+    link = article.get("link")
+    if title and link:
+        lines.append(f"- [{title}]({link})")
+
+news_content = "\n".join(lines)
+
+README_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "README.md")
+START = "<!-- NEWS-START -->"
+END = "<!-- NEWS-END -->"
+
+with open(README_PATH, "r", encoding="utf-8") as f:
+    content = f.read()
+
+start_idx = content.find(START)
+end_idx = content.find(END, start_idx)
+
+if start_idx == -1 or end_idx == -1:
+    raise ValueError("News markers not found in README")
+
+new_content = (
+    content[: start_idx + len(START)]
+    + "\n"
+    + news_content
+    + "\n"
+    + content[end_idx:]
+)
+
+with open(README_PATH, "w", encoding="utf-8") as f:
+    f.write(new_content)


### PR DESCRIPTION
## Summary
- add news markers to README
- add Python script to fetch news data
- add GitHub Actions workflow to update the news daily

## Testing
- `python3 -m py_compile scripts/update_news.py`


------
https://chatgpt.com/codex/tasks/task_b_684d8b671be0833381e0dcdf470849fe