### PR TITLE
Enhance profile visuals with animated header and stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-### Hi there 👋
-My name is praveen, I am a software Engineer by profession having near about 3 years of experience. 
+<p align="center">
+  <img src="media/header-bg.svg" width="100%" alt="Tech - Software Engineering - Agentic AI">
+</p>
+
+### Hi there <img src="media/wave.gif" width="30" alt="wave">
+My name is praveen, I am a software Engineer by profession having near about 3 years of experience.
 I started off my career as a software developer. After working near about 1.5 years on python I have learned alot of things like Python, JavaScript, Flask, Django, PostgreSQL etc. After that I started my new journey as a Software Engineer working on a Data Platform which allowed me to learn pandas, matplotlib, Node.js, Hadoop, Hive, SQL, AWS services and many more...
 Currently I am upskilling myself on Spark so that I can take my work to the next level. 
 
-![[Header](https://youtu.be/oCITP8OcqjE "cover")]
 
 
 ## Latest AI News
@@ -29,6 +32,8 @@ Currently I am upskilling myself on Spark so that I can take my work to the next
 
 
 ![Praveen's GitHub stats](https://github-readme-stats.vercel.app/api?username=krpraveen0&count_private=true&show_icons=true&theme=radical)
+![GitHub Streak](https://streak-stats.demolab.com?user=krpraveen0&theme=radical)
+![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=krpraveen0&layout=compact&theme=radical)
 
 <a href="https://github.com/krpraveen0/Taskmate">
   <img align="center" src="https://github-readme-stats.vercel.app/api/pin/?username=krpraveen0&repo=Taskmate&title_color=ffffff&text_color=c9cacc&icon_color=2bbc8a&bg_color=1d1f21" />
@@ -54,6 +59,10 @@ Currently I am upskilling myself on Spark so that I can take my work to the next
 <a href="https://github.com/krpraveen0/Home-Automation-System">
   <img align="center" src="https://github-readme-stats.vercel.app/api/pin/?username=krpraveen0&repo=Home-Automation-System&title_color=ffffff&text_color=c9cacc&icon_color=2bbc8a&bg_color=1d1f21" />
 </a>
+
+![GitHub Trophies](https://github-profile-trophy.vercel.app/?username=krpraveen0&theme=radical&no-frame=true&margin-w=10)
+
+![Contribution Graph](https://github-readme-activity-graph.cyclic.app/graph?username=krpraveen0&theme=github-compact&hide_border=true)
 
 <!-- social media icons -->
 [![GitHub][2.1]][2]

--- a/media/header-bg.svg
+++ b/media/header-bg.svg
@@ -1,0 +1,16 @@
+<svg width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff6b6b">
+        <animate attributeName="stop-color" values="#ff6b6b;#f06595;#845ef7;#ff6b6b" dur="10s" repeatCount="indefinite" />
+      </stop>
+      <stop offset="100%" stop-color="#845ef7">
+        <animate attributeName="stop-color" values="#845ef7;#ff6b6b;#f06595;#845ef7" dur="10s" repeatCount="indefinite" />
+      </stop>
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#grad)" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="26" font-family="Verdana" fill="#ffffff">
+    Tech • Software Engineering • Agentic AI
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- add animated SVG header to highlight technologies
- show wave gif in greeting
- extend GitHub stats with streak, top languages, trophies and activity graph

## Testing
- `python3 scripts/update_news.py` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_684d8ffe6a7c8333a2bfa0fd5a351966